### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Fenrur/Signal/security/code-scanning/1](https://github.com/Fenrur/Signal/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimum required access for this CI workflow. Since the workflow simply checks out the repository and runs Gradle build/tests, it only needs read access to repository contents. No job step requires write access to issues, pull requests, or contents.

The best way to fix this without changing existing functionality is to add a workflow‑level `permissions` block near the top of `.github/workflows/ci.yml`, for example right after the `name:` field and before the `on:` block. This will apply to all jobs in the workflow (currently just `build`) and keep the file simple. The block should set `contents: read`, which is the minimal recommended permission for typical CI that only reads the repo. No additional imports or definitions are needed; this is a pure YAML configuration change inside the existing workflow file.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`). The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
